### PR TITLE
Remove quotes from the slug text

### DIFF
--- a/cnxcommon/urlslug.py
+++ b/cnxcommon/urlslug.py
@@ -1,7 +1,9 @@
 # -*- coding: utf-8 -*-
 import re
-
 from slugify import slugify
+
+
+QUOTE_PATTERN = re.compile(r'[\']+')
 
 
 def generate_slug(book_title, *other_titles):
@@ -32,7 +34,11 @@ def generate_slug(book_title, *other_titles):
         book_title = slugify(remove_html_tags(book_title))
         return book_title
 
-    section_title = slugify(remove_html_tags(other_titles[-1]))
+    section_title = other_titles[-1]
+    # Remove any quotes from the textp
+    section_title = QUOTE_PATTERN.sub('', section_title)
+
+    section_title = slugify(remove_html_tags(section_title))
 
     if re.match(r"^\d", section_title):  # if section title starts with a digit
         # we must already have the chapter and section numbers

--- a/tests/test_urlslug.py
+++ b/tests/test_urlslug.py
@@ -143,7 +143,7 @@ class TestSlugGenerator:
         ]
 
         expectations = [
-            '12-4-viscosity-and-laminar-flow-poiseuille-s-law',
+            '12-4-viscosity-and-laminar-flow-poiseuilles-law',
             '1-problems-exercises',
             '1-1-the-science-of-biology',
             'preface',
@@ -152,3 +152,17 @@ class TestSlugGenerator:
 
         for index, book in enumerate(books):
             assert expectations[index] == generate_slug(*book)
+
+    # https://github.com/openstax/cnx/issues/389
+    def test_removes_apostrophes(self):
+        titles = (
+            'University Physics Volume 2',
+            '<span class="os-text">Unit 2. Electricity and Magnetism</span>',
+            '<span class="os-number">9</span><span class="os-divider"> </span><span class="os-text">Current and Resistance</span>',
+            '<span class="os-number">9.4</span><span class="os-divider"> </span><span class="os-text">Ohm\'s Law</span>',
+        )
+
+        slug = generate_slug(*titles)
+
+        expected = '9-4-ohms-law'
+        assert expected == slug


### PR DESCRIPTION
This removes quotes from the slug text. See openstax/cnx#389 for details.