### PR TITLE
Include ancestor chapter number in url slug

### DIFF
--- a/cnxcommon/urlslug.py
+++ b/cnxcommon/urlslug.py
@@ -38,21 +38,23 @@ def generate_slug(book_title, *other_titles):
     # Remove any quotes from the textp
     section_title = QUOTE_PATTERN.sub('', section_title)
 
-    section_title = slugify(remove_html_tags(section_title))
+    result = remove_html_tags(section_title)
+    if not get_os_number(section_title):
+        # find the chapter number
+        for title in reversed(other_titles[:-1]):
+            number = get_os_number(title)
+            if number:
+                result = '{}-{}'.format(number, result)
+                break
 
-    if re.match(r"^\d", section_title):  # if section title starts with a digit
-        # we must already have the chapter and section numbers
-        return section_title
-    else:  # find the chapter number
-        try:
-            chapter_title = remove_html_tags(other_titles[-2])
-            chapter_number = re.split(r"^([0-9\.]*)?(.*)$", chapter_title)[1]
-            section_title = "{}-{}".format(chapter_number, section_title) if chapter_number else section_title
-        except IndexError:
-            pass  # chapter title not present
-
-        return section_title
+    return slugify(result)
 
 
 def remove_html_tags(title):
     return re.sub(r"<.*?>", "", title)
+
+
+def get_os_number(title):
+    m = re.search('<span class="os-number">([^<]+)</span>', title)
+    if m:
+        return m.group(1)

--- a/tests/test_urlslug.py
+++ b/tests/test_urlslug.py
@@ -98,7 +98,7 @@ class TestSlugGenerator:
         it can find it in the chapter title instead.
         """
         book_title = "college-physics"
-        chapter_title = "1 Introduction: The Nature of Science and Physics"
+        chapter_title = '<span class="os-number">1</span> Introduction: The Nature of Science and Physics'
         section_title = "problems-and-exercises"
         expected = "1-problems-and-exercises"
         actual = generate_slug(book_title, chapter_title, section_title)
@@ -139,7 +139,25 @@ class TestSlugGenerator:
                 '<span class="os-text">Preface</span>',
             ), (
                 'Biology 2e',
-            ),
+            ), (
+                'A Study of How a Region Can Lever Participation',
+                '<span class="os-text">21st Century Economic Development</span>',
+            ), (
+                'A Study of How a Region Can Lever Participation',
+                '<span class="os-text">21st Century Economic Development</span>',
+                '<span class="os-text">Introduction</span>',
+            ), (
+                'Astronomy',
+                '<span class=\"os-number\">2</span><span class=\"os-divider\"> </span><span class=\"os-text\">Observing the Sky: The Birth of Astronomy</span>',
+                '<span class=\"os-text\">Exercises</span>',
+                '<span class=\"os-text\">Review Questions</span>',
+            ), (
+                'Astronomy',
+                '<span class=\"os-number\">2</span><span class=\"os-divider\"> </span><span class=\"os-text\">Observing the Sky: The Birth of Astronomy</span>',
+                '<span class=\"os-number\">2.1</span><span class=\"os-divider\"> </span><span class=\"os-text\">The Sky Above</span>',
+                '<span class=\"os-text\">Exercises</span>',
+                '<span class=\"os-text\">Review Questions</span>',
+            )
         ]
 
         expectations = [
@@ -148,6 +166,10 @@ class TestSlugGenerator:
             '1-1-the-science-of-biology',
             'preface',
             'biology-2e',
+            '21st-century-economic-development',
+            'introduction',
+            '2-review-questions',
+            '2-1-review-questions',
         ]
 
         for index, book in enumerate(books):


### PR DESCRIPTION
Previously, `generate_slug` only look up one level for the parent
chapter number if the title itself doesn't have a number.  We need it to
look up all the way for the closest ancestor that has a number and use
it in the slug.

Also change the way `generate_slug` looks for chapter number.  It used
to remove the html tags first (e.g. `<span class="os-number">`) and used
a regular expression to look for the chapter number.  For a title like
"21st Century Economic Development", it'll think that "21" is the
chapter number, but it's actually part of the title.