### PR TITLE
Fix unicode encode error when generating slugs

### DIFF
--- a/cnxcommon/urlslug.py
+++ b/cnxcommon/urlslug.py
@@ -1,11 +1,15 @@
 # -*- coding: utf-8 -*-
 import re
+
 from slugify import slugify
+
+from . import utils
 
 
 QUOTE_PATTERN = re.compile(r'[\']+')
 
 
+@utils.ensure_unicode
 def generate_slug(book_title, *other_titles):
     """Generates a slug for a book title or a section title.
 
@@ -35,10 +39,12 @@ def generate_slug(book_title, *other_titles):
         return book_title
 
     section_title = other_titles[-1]
+    if isinstance(section_title, bytes):
+        section_title = section_title.decode('utf-8')
     # Remove any quotes from the textp
     section_title = QUOTE_PATTERN.sub('', section_title)
 
-    result = remove_html_tags(section_title)
+    result = slugify(remove_html_tags(section_title))
     if not get_os_number(section_title):
         # find the chapter number
         for title in reversed(other_titles[:-1]):
@@ -50,10 +56,12 @@ def generate_slug(book_title, *other_titles):
     return slugify(result)
 
 
+@utils.ensure_unicode
 def remove_html_tags(title):
     return re.sub(r"<.*?>", "", title)
 
 
+@utils.ensure_unicode
 def get_os_number(title):
     m = re.search('<span class="os-number">([^<]+)</span>', title)
     if m:

--- a/cnxcommon/utils.py
+++ b/cnxcommon/utils.py
@@ -1,0 +1,17 @@
+# -*- coding: utf-8 -*-
+import functools
+
+
+def ensure_unicode(f):
+    @functools.wraps(f)
+    def inner(*args, **kwargs):
+        args = list(args)
+        for i, arg in enumerate(args):
+            if isinstance(arg, bytes):
+                args[i] = arg.decode('utf-8')
+        for kw, arg in kwargs.items():
+            if isinstance(arg, bytes):
+                kwargs[kw] = arg.decode('utf-8')
+        return f(*args, **kwargs)
+
+    return inner

--- a/tests/test_urlslug.py
+++ b/tests/test_urlslug.py
@@ -188,3 +188,25 @@ class TestSlugGenerator:
 
         expected = '9-4-ohms-law'
         assert expected == slug
+
+    def test_handling_bytes(self):
+        titles = (
+            b'College Physics',
+            u'<span class="os-number">5</span><span class="os-divider"> </span><span class="os-text">'
+            u'Further Applications of Newton’s Laws: Friction, Drag, and Elasticity</span>'.encode('utf-8'),
+            u'<span class="os-text">Introduction: Further Applications of Newton’s Laws</span>'.encode('utf-8')
+        )
+
+        slug = generate_slug(*titles)
+        assert slug == '5-introduction-further-applications-of-newtons-laws'
+
+    def test_handling_unicode(self):
+        titles = (
+            u'College Physics',
+            u'<span class="os-number">5</span><span class="os-divider"> </span><span class="os-text">'
+            u'Further Applications of Newton’s Laws: Friction, Drag, and Elasticity</span>',
+            u'<span class="os-text">Introduction: Further Applications of Newton’s Laws</span>',
+        )
+
+        slug = generate_slug(*titles)
+        assert slug == '5-introduction-further-applications-of-newtons-laws'


### PR DESCRIPTION
When baking College Physics on qa.cnx.org:

```
Traceback (most recent call last):
  File "/var/cnx/venvs/publishing/local/lib/python2.7/site-packages/celery/app/trace.py", line 382, in trace_task
    R = retval = fun(*args, **kwargs)
  File "/var/cnx/venvs/publishing/src/cnx-publishing/cnxpublishing/tasks.py", line 31, in __call__
    return super(PyramidAwareTask, self).__call__(*args, **kwargs)
  File "/var/cnx/venvs/publishing/local/lib/python2.7/site-packages/celery/app/trace.py", line 641, in __protected_call__
    return self.run(*args, **kwargs)
  File "/var/cnx/venvs/publishing/src/cnx-publishing/cnxpublishing/db.py", line 74, in wrapped
    return func(*args, **kwargs)
  File "/var/cnx/venvs/publishing/src/cnx-publishing/cnxpublishing/subscribers.py", line 167, in baking_processor
    bake(binder, recipe_id, publisher, message, cursor=cursor)
  File "/var/cnx/venvs/publishing/src/cnx-publishing/cnxpublishing/db.py", line 70, in wrapped
    return func(*args, **kwargs)
  File "/var/cnx/venvs/publishing/src/cnx-publishing/cnxpublishing/bake.py", line 92, in bake
    amend_tree_with_slugs(tree)
  File "/var/cnx/venvs/publishing/src/cnx-publishing/cnxpublishing/utils.py", line 70, in amend_tree_with_slugs
    amend_tree_with_slugs(node, title_seq)
  File "/var/cnx/venvs/publishing/src/cnx-publishing/cnxpublishing/utils.py", line 70, in amend_tree_with_slugs
    amend_tree_with_slugs(node, title_seq)
  File "/var/cnx/venvs/publishing/src/cnx-publishing/cnxpublishing/utils.py", line 67, in amend_tree_with_slugs
    tree['slug'] = generate_slug(*title_seq)
  File "/var/cnx/venvs/publishing/local/lib/python2.7/site-packages/cnxcommon/urlslug.py", line 47, in generate_slug
    result = '{}-{}'.format(number, result)
UnicodeEncodeError: 'ascii' codec can't encode character u'\u2019' in position 32: ordinal not in range(128)
```

This is because College Physics contains unicode apostrophes in some of
its chapters and sections.