### PR TITLE
Look for discardable elements when generating slugs

### DIFF
--- a/cnxcommon/urlslug.py
+++ b/cnxcommon/urlslug.py
@@ -58,7 +58,7 @@ def generate_slug(book_title, *other_titles):
 
 @utils.ensure_unicode
 def remove_html_tags(title):
-    tmp_title = re.sub(r'<span class="os-throwaway">([^<]+)</span>', "", title)
+    tmp_title = re.sub(r'<span class="os-part-text">([^<]+)</span>', "", title)
     return re.sub(r"<.*?>", "", tmp_title)
 
 

--- a/cnxcommon/urlslug.py
+++ b/cnxcommon/urlslug.py
@@ -58,7 +58,8 @@ def generate_slug(book_title, *other_titles):
 
 @utils.ensure_unicode
 def remove_html_tags(title):
-    return re.sub(r"<.*?>", "", title)
+    tmp_title = re.sub(r'<span class="os-throwaway">([^<]+)</span>', "", title)
+    return re.sub(r"<.*?>", "", tmp_title)
 
 
 @utils.ensure_unicode

--- a/tests/test_urlslug.py
+++ b/tests/test_urlslug.py
@@ -216,7 +216,18 @@ class TestSlugGenerator:
         https://github.com/openstax/cnx/issues/972
         """
         book_title = "college-physics"
-        chapter_title = '<span class="os-throwaway">Chapter</span><span class="os-divider"> </span><span class="os-number">4</span><span class="os-divider"> </span><span class="os-text">Kinematics in 7 Dimensions</span>'
+        chapter_title = '<span class="os-part-text">Chapter</span><span class="os-divider"> </span><span class="os-number">4</span><span class="os-divider"> </span><span class="os-text">Kinematics in 7 Dimensions</span>'
+        expected = "4-kinematics-in-7-dimensions"
+        actual = generate_slug(book_title, chapter_title)
+
+        assert expected == actual
+
+    def test_discard_part_of_slug_nested(self):
+        """Acceptance test for the criteria described in:
+        https://github.com/openstax/cnx/issues/972
+        """
+        book_title = "college-physics"
+        chapter_title = '<span class="os-wrapper-thingy"><span class="os-part-text">Chapter</span><span class="os-divider"> </span><span class="os-number">4</span><span class="os-divider"> </span></span><span class="os-text">Kinematics in 7 Dimensions</span>'
         expected = "4-kinematics-in-7-dimensions"
         actual = generate_slug(book_title, chapter_title)
 

--- a/tests/test_urlslug.py
+++ b/tests/test_urlslug.py
@@ -210,3 +210,14 @@ class TestSlugGenerator:
 
         slug = generate_slug(*titles)
         assert slug == '5-introduction-further-applications-of-newtons-laws'
+
+    def test_discard_part_of_slug(self):
+        """Acceptance test for the criteria described in:
+        https://github.com/openstax/cnx/issues/972
+        """
+        book_title = "college-physics"
+        chapter_title = '<span class="os-throwaway">Chapter</span><span class="os-divider"> </span><span class="os-number">4</span><span class="os-divider"> </span><span class="os-text">Kinematics in 7 Dimensions</span>'
+        expected = "4-kinematics-in-7-dimensions"
+        actual = generate_slug(book_title, chapter_title)
+
+        assert expected == actual


### PR DESCRIPTION
As part of a change to recipes, titles may contain the text Chapter
which needs to be removed prior to generating slugs. This change
provides a mechanism by which elements with a specific class get
removed along with HTML tags before calculating a final slug value.