### PR TITLE
remove os-part-text from chapters also

### DIFF
--- a/cnxcommon/urlslug.py
+++ b/cnxcommon/urlslug.py
@@ -7,6 +7,7 @@ from . import utils
 
 
 QUOTE_PATTERN = re.compile(r'[\']+')
+REMOVE_PART_PATTERN = re.compile(r'<span class="os-part-text">([^<]+)</span>')
 
 
 @utils.ensure_unicode
@@ -58,13 +59,13 @@ def generate_slug(book_title, *other_titles):
 
 @utils.ensure_unicode
 def remove_html_tags(title):
-    tmp_title = re.sub(r'<span class="os-part-text">([^<]+)</span>', "", title)
+    tmp_title = REMOVE_PART_PATTERN.sub('', title)
     return re.sub(r"<.*?>", "", tmp_title)
 
 
 @utils.ensure_unicode
 def get_os_number(title):
-    tmp_title = re.sub(r'<span class="os-part-text">([^<]+)</span>', "", title)
+    tmp_title = REMOVE_PART_PATTERN.sub('', title)
     m = re.search('<span class="os-number">([^<]+)</span>', tmp_title)
     if m:
         return m.group(1)

--- a/cnxcommon/urlslug.py
+++ b/cnxcommon/urlslug.py
@@ -64,6 +64,7 @@ def remove_html_tags(title):
 
 @utils.ensure_unicode
 def get_os_number(title):
-    m = re.search('<span class="os-number">([^<]+)</span>', title)
+    tmp_title = re.sub(r'<span class="os-part-text">([^<]+)</span>', "", title)
+    m = re.search('<span class="os-number">([^<]+)</span>', tmp_title)
     if m:
         return m.group(1)

--- a/tests/test_urlslug.py
+++ b/tests/test_urlslug.py
@@ -227,8 +227,9 @@ class TestSlugGenerator:
         https://github.com/openstax/cnx/issues/972
         """
         book_title = "college-physics"
-        chapter_title = '<span class="os-wrapper-thingy"><span class="os-part-text">Chapter</span><span class="os-divider"> </span><span class="os-number">4</span><span class="os-divider"> </span></span><span class="os-text">Kinematics in 7 Dimensions</span>'
-        expected = "4-kinematics-in-7-dimensions"
-        actual = generate_slug(book_title, chapter_title)
+        chapter_title = '<span class="os-number"><span class="os-part-text">Chapter </span>2</span><span class="os-divider"> </span><span data-type="" itemprop="" class="os-text">Motion in One Dimension</span>'
+        section_title = '<span class="os-text">Key Terms</span>'
+        expected = "2-key-terms"
+        actual = generate_slug(book_title, chapter_title, section_title)
 
         assert expected == actual


### PR DESCRIPTION
refs openstax/cnx#972

Recipes used to begin the chapter title with the chapter number. Beginning with `hs-physics` the chapter title contains `Chapter` at the beginning. The chapter number is prepended to items that occur in multiple chapters (e.g. "Key Terms") to distinguish them because each should have a unique URL.